### PR TITLE
Next phase rcl get_type_description srv

### DIFF
--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -554,12 +554,15 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
 
 /// Initialize the node's ~/get_type_description service.
 /**
- * This function initializes the node's private ~/get_type_description service
+ * This function initializes the node's ~/get_type_description service
  * which can be used to retrieve information about types used by the node's
  * publishers, subscribers, services or actions.
  *
- * Note that this function will be called in `rcl_init_node` if the node option
- * `enable_type_description_service` is set to true.
+ * Note that this will not register any callback for the service, client-level code
+ * must register rcl_node_type_description_service_handle_request or a custom callback
+ * to handle incoming requests, via that client's executor/waitset capabilities.
+ *
+ * This will initialize the node's type cache, if it has not been initialized already.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -36,6 +36,7 @@ extern "C"
 extern const char * const RCL_DISABLE_LOANED_MESSAGES_ENV_VAR;
 
 typedef struct rcl_node_impl_s rcl_node_impl_t;
+typedef struct rcl_service_s rcl_service_t;
 
 /// Structure which encapsulates a ROS Node.
 typedef struct rcl_node_s
@@ -599,6 +600,52 @@ rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node);
+
+
+/// Returns a pointer to the node's ~/get_type_description service.
+/**
+ * On success, sets service_out to the initialized service.
+ * rcl_node_type_description_service_init must be called before this.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node the handle to the node
+ * \return #RCL_RET_OK if valid service was returned successfully, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_NOT_INIT if the service hasn't yet been initialized, or
+ * \return #RCL_RET_ERROR if an unspecified error occurs.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t rcl_node_get_type_description_service(
+  const rcl_node_t * node,
+  rcl_service_t ** service_out);
+
+
+/// Process a single pending request to the GetTypeDescription service.
+/**
+ * Should be registered as the callback for the type description service
+ * by any client instantiating that service.
+ * It is not intended to be called directly by users.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node the handle to the node
+ */
+RCL_PUBLIC
+void rcl_node_type_description_service_on_new_request(rcl_node_t * node);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -33,6 +33,8 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#include "type_description_interfaces/srv/get_type_description.h"
+
 extern const char * const RCL_DISABLE_LOANED_MESSAGES_ENV_VAR;
 
 typedef struct rcl_node_impl_s rcl_node_impl_t;
@@ -645,7 +647,11 @@ rcl_ret_t rcl_node_get_type_description_service(
  * \param[in] node the handle to the node
  */
 RCL_PUBLIC
-void rcl_node_type_description_service_on_new_request(rcl_node_t * node);
+void rcl_node_type_description_service_handle_request(
+  rcl_node_t * node,
+  rmw_request_id_t request_header,
+  const type_description_interfaces__srv__GetTypeDescription_Request * request,
+  type_description_interfaces__srv__GetTypeDescription_Response * response);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -618,7 +618,9 @@ rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node);
  * Lock-Free          | Yes
  *
  * \param[in] node the handle to the node
+ * \param[out] service_out Handle to pointer that will be set
  * \return #RCL_RET_OK if valid service was returned successfully, or
+ * \return #RCL_RET_NODE_INVALID if node is invalid, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_NOT_INIT if the service hasn't yet been initialized, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
@@ -632,8 +634,7 @@ rcl_ret_t rcl_node_get_type_description_service(
 
 /// Process a single pending request to the GetTypeDescription service.
 /**
- * Should be registered as the callback for the type description service
- * by any client instantiating that service.
+ * This function may be called to handle incoming requests by any client starting the service.
  * It is not intended to be called directly by users.
  *
  * <hr>
@@ -645,6 +646,10 @@ rcl_ret_t rcl_node_get_type_description_service(
  * Lock-Free          | Yes
  *
  * \param[in] node the handle to the node
+ * \param[in] request_header ID of the incoming request
+ * \param[in] request Request that came in to the service
+ * \param[out] response Allocated, uninitialized response to the request
+ * \return void
  */
 RCL_PUBLIC
 void rcl_node_type_description_service_handle_request(

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -657,7 +657,7 @@ rcl_ret_t rcl_node_get_type_description_service(
 RCL_PUBLIC
 void rcl_node_type_description_service_handle_request(
   rcl_node_t * node,
-  rmw_request_id_t request_header,
+  const rmw_request_id_t * request_header,
   const type_description_interfaces__srv__GetTypeDescription_Request * request,
   type_description_interfaces__srv__GetTypeDescription_Response * response);
 

--- a/rcl/include/rcl/node_options.h
+++ b/rcl/include/rcl/node_options.h
@@ -56,6 +56,7 @@ typedef struct rcl_node_options_s
   rmw_qos_profile_t rosout_qos;
 
   /// Register the ~/get_type_description service. Defaults to false.
+  // Deprecated: use parameter "enable_type_description_service" in language clients instead.
   bool enable_type_description_service;
 } rcl_node_options_t;
 

--- a/rcl/include/rcl/node_options.h
+++ b/rcl/include/rcl/node_options.h
@@ -54,10 +54,6 @@ typedef struct rcl_node_options_s
 
   /// Middleware quality of service settings for /rosout.
   rmw_qos_profile_t rosout_qos;
-
-  /// Register the ~/get_type_description service. Defaults to false.
-  // Deprecated: use parameter "enable_type_description_service" in language clients instead.
-  bool enable_type_description_service;
 } rcl_node_options_t;
 
 /// Return the default node options in a rcl_node_options_t.

--- a/rcl/include/rcl/node_type_cache.h
+++ b/rcl/include/rcl/node_type_cache.h
@@ -37,6 +37,8 @@ typedef struct rcl_type_info_t
 /**
  * This function initializes hash map of the node's type cache such that types
  * can be registered and retrieved.
+ * Note that to correctly capture all types used by a node, this needs to be called
+ * before any "builtin" publishers or services are created.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/node_type_cache.h
+++ b/rcl/include/rcl/node_type_cache.h
@@ -52,6 +52,7 @@ typedef struct rcl_type_info_t
  * \return #RCL_RET_NODE_INVALID if the given `node` is invalid, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t rcl_node_type_cache_init(rcl_node_t * node);
 
@@ -95,6 +96,7 @@ bool rcl_node_type_cache_is_valid(const rcl_node_t * node);
  * \return #RCL_RET_NODE_INVALID if the given `node` is invalid, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t rcl_node_type_cache_fini(rcl_node_t * node);
 

--- a/rcl/src/rcl/node_options.c
+++ b/rcl/src/rcl/node_options.c
@@ -36,7 +36,6 @@ rcl_node_get_default_options()
     .arguments = rcl_get_zero_initialized_arguments(),
     .enable_rosout = true,
     .rosout_qos = rcl_qos_profile_rosout_default,
-    .enable_type_description_service = false,
   };
   return default_options;
 }
@@ -62,7 +61,6 @@ rcl_node_options_copy(
   options_out->use_global_arguments = options->use_global_arguments;
   options_out->enable_rosout = options->enable_rosout;
   options_out->rosout_qos = options->rosout_qos;
-  options_out->enable_type_description_service = options->enable_type_description_service;
   if (NULL != options->arguments.impl) {
     return rcl_arguments_copy(&(options->arguments), &(options_out->arguments));
   }

--- a/rcl/src/rcl/node_type_cache.c
+++ b/rcl/src/rcl/node_type_cache.c
@@ -205,17 +205,6 @@ rcl_ret_t rcl_node_type_cache_register_type(
     return RCL_RET_ERROR;
   }
 
-  // char * hash_str = NULL;
-  // rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  // rcutils_ret_t hash_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
-  // if (hash_ret == RCUTILS_RET_OK) {
-    // RCUTILS_LOG_WARN("Registered %s: %s.\n",
-    //   type_description->type_description.type_name.data, hash_str);
-  // } else {
-  //   assert(false);
-  // }
-  // allocator.deallocate(hash_str, allocator.state);
-
   return RCL_RET_OK;
 }
 
@@ -228,10 +217,6 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(type_hash, RCL_RET_INVALID_ARGUMENT);
 
-  // char * hash_str = NULL;
-  // rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  // rcutils_ret_t rcutils_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
-
   if (RCUTILS_RET_OK !=
     rcutils_hash_map_get(
       &node->impl->registered_types_by_type_hash,
@@ -239,12 +224,6 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
   {
     RCL_SET_ERROR_MSG("Failed to unregister hash");
     return RCL_RET_ERROR;
-    // if (rcutils_ret == RCUTILS_RET_OK) {
-    //   RCUTILS_LOG_ERROR("Type not registered with type cache %s.", hash_str);
-    // } else {
-    //   RCL_SET_ERROR_MSG("Type not registered with type cache - type hash failed to print.");
-    // }
-    // return RCL_RET_INVALID_ARGUMENT;
   }
 
   if (--type_info.num_registrations > 0) {
@@ -271,9 +250,6 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
     type_description_interfaces__msg__TypeSource__Sequence__destroy(
       type_info.type_info.type_sources);
   }
-
-  // RCUTILS_LOG_WARN("UNREgistered %s.", hash_str);
-  // allocator.deallocate(hash_str, allocator.state);
 
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/node_type_cache.c
+++ b/rcl/src/rcl/node_type_cache.c
@@ -182,7 +182,7 @@ rcl_ret_t rcl_node_type_cache_register_type(
     type_info_with_registrations.type_info.type_sources =
       rcl_convert_type_source_sequence_runtime_to_msg(type_description_sources);
     RCL_CHECK_FOR_NULL_WITH_MSG(
-      type_info_with_registrations.type_info.type_description,
+      type_info_with_registrations.type_info.type_sources,
       "converting type sources struct failed",
       type_description_interfaces__msg__TypeDescription__destroy(
         type_info_with_registrations.type_info.type_description);

--- a/rcl/src/rcl/node_type_cache.c
+++ b/rcl/src/rcl/node_type_cache.c
@@ -222,7 +222,7 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
       &node->impl->registered_types_by_type_hash,
       type_hash, &type_info))
   {
-    RCL_SET_ERROR_MSG("Failed to unregister hash");
+    RCL_SET_ERROR_MSG("Failed to unregister type, hash not present in map.");
     return RCL_RET_ERROR;
   }
 

--- a/rcl/src/rcl/node_type_cache.c
+++ b/rcl/src/rcl/node_type_cache.c
@@ -47,6 +47,10 @@ rcl_ret_t rcl_node_type_cache_init(rcl_node_t * node)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
+  if (NULL != node->impl->registered_types_by_type_hash.impl) {
+    // already initialized
+    return RCL_RET_OK;
+  }
 
   rcutils_ret_t ret = rcutils_hash_map_init(
     &node->impl->registered_types_by_type_hash, 2, sizeof(rosidl_type_hash_t),
@@ -77,8 +81,6 @@ rcl_ret_t rcl_node_type_cache_fini(rcl_node_t * node)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
-
-  RCUTILS_LOG_ERROR("FINI!");
 
   // Clean up any remaining types.
   rosidl_type_hash_t key;
@@ -203,16 +205,16 @@ rcl_ret_t rcl_node_type_cache_register_type(
     return RCL_RET_ERROR;
   }
 
-  char * hash_str = NULL;
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rcutils_ret_t hash_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
-  if (hash_ret == RCUTILS_RET_OK) {
-    RCUTILS_LOG_WARN("Registered %s: %s.\n",
-      type_description->type_description.type_name.data, hash_str);
-    allocator.deallocate(hash_str, allocator.state);
-  } else {
-    assert(false);
-  }
+  // char * hash_str = NULL;
+  // rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  // rcutils_ret_t hash_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
+  // if (hash_ret == RCUTILS_RET_OK) {
+    // RCUTILS_LOG_WARN("Registered %s: %s.\n",
+    //   type_description->type_description.type_name.data, hash_str);
+  // } else {
+  //   assert(false);
+  // }
+  // allocator.deallocate(hash_str, allocator.state);
 
   return RCL_RET_OK;
 }
@@ -226,21 +228,23 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(type_hash, RCL_RET_INVALID_ARGUMENT);
 
-  char * hash_str = NULL;
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rcutils_ret_t rcutils_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
+  // char * hash_str = NULL;
+  // rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  // rcutils_ret_t rcutils_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
 
   if (RCUTILS_RET_OK !=
     rcutils_hash_map_get(
       &node->impl->registered_types_by_type_hash,
       type_hash, &type_info))
   {
-    if (rcutils_ret == RCUTILS_RET_OK) {
-      RCUTILS_LOG_ERROR("Type not registered with type cache %s.", hash_str);
-    } else {
-      RCL_SET_ERROR_MSG("Type not registered with type cache - type hash failed to print.");
-    }
-    return RCL_RET_INVALID_ARGUMENT;
+    RCL_SET_ERROR_MSG("Failed to unregister hash");
+    return RCL_RET_ERROR;
+    // if (rcutils_ret == RCUTILS_RET_OK) {
+    //   RCUTILS_LOG_ERROR("Type not registered with type cache %s.", hash_str);
+    // } else {
+    //   RCL_SET_ERROR_MSG("Type not registered with type cache - type hash failed to print.");
+    // }
+    // return RCL_RET_INVALID_ARGUMENT;
   }
 
   if (--type_info.num_registrations > 0) {
@@ -268,8 +272,8 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
       type_info.type_info.type_sources);
   }
 
-  RCUTILS_LOG_WARN("UNREgistered %s.", hash_str);
-  allocator.deallocate(hash_str, allocator.state);
+  // RCUTILS_LOG_WARN("UNREgistered %s.", hash_str);
+  // allocator.deallocate(hash_str, allocator.state);
 
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/node_type_cache.c
+++ b/rcl/src/rcl/node_type_cache.c
@@ -78,6 +78,8 @@ rcl_ret_t rcl_node_type_cache_fini(rcl_node_t * node)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
 
+  RCUTILS_LOG_ERROR("FINI!");
+
   // Clean up any remaining types.
   rosidl_type_hash_t key;
   rcl_type_info_with_registration_count_t type_info_with_registrations;
@@ -201,6 +203,17 @@ rcl_ret_t rcl_node_type_cache_register_type(
     return RCL_RET_ERROR;
   }
 
+  char * hash_str = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t hash_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
+  if (hash_ret == RCUTILS_RET_OK) {
+    RCUTILS_LOG_WARN("Registered %s: %s.\n",
+      type_description->type_description.type_name.data, hash_str);
+    allocator.deallocate(hash_str, allocator.state);
+  } else {
+    assert(false);
+  }
+
   return RCL_RET_OK;
 }
 
@@ -213,13 +226,21 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(type_hash, RCL_RET_INVALID_ARGUMENT);
 
+  char * hash_str = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t rcutils_ret = rosidl_stringify_type_hash(type_hash, allocator, &hash_str);
+
   if (RCUTILS_RET_OK !=
     rcutils_hash_map_get(
       &node->impl->registered_types_by_type_hash,
       type_hash, &type_info))
   {
-    RCL_SET_ERROR_MSG("Failed to unregister type");
-    return RCL_RET_ERROR;
+    if (rcutils_ret == RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Type not registered with type cache %s.", hash_str);
+    } else {
+      RCL_SET_ERROR_MSG("Type not registered with type cache - type hash failed to print.");
+    }
+    return RCL_RET_INVALID_ARGUMENT;
   }
 
   if (--type_info.num_registrations > 0) {
@@ -246,6 +267,9 @@ rcl_ret_t rcl_node_type_cache_unregister_type(
     type_description_interfaces__msg__TypeSource__Sequence__destroy(
       type_info.type_info.type_sources);
   }
+
+  RCUTILS_LOG_WARN("UNREgistered %s.", hash_str);
+  allocator.deallocate(hash_str, allocator.state);
 
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/type_description_conversions.c
+++ b/rcl/src/rcl/type_description_conversions.c
@@ -252,10 +252,12 @@ rcl_convert_type_source_sequence_runtime_to_msg(
       goto fail;
     }
     // raw_file_contents
-    if (!rosidl_runtime_c__String__copy(
-        &(runtime_type_sources->data[i].raw_file_contents), &(out->data[i].raw_file_contents)))
-    {
-      goto fail;
+    if (runtime_type_sources->data[i].raw_file_contents.size > 0) {
+      if (!rosidl_runtime_c__String__copy(
+          &(runtime_type_sources->data[i].raw_file_contents), &(out->data[i].raw_file_contents)))
+      {
+        goto fail;
+      }
     }
   }
 

--- a/rcl/test/rcl/test_get_type_description_service.cpp
+++ b/rcl/test/rcl/test_get_type_description_service.cpp
@@ -105,7 +105,6 @@ public:
   rcl_context_t * context_ptr;
   rcl_node_t * node_ptr;
   char get_type_description_service_name[256];
-  bool enable_get_type_description_service;
 
   virtual bool get_type_description_service_enabled() const
   {
@@ -132,7 +131,6 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "test_service_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    node_options.enable_type_description_service = get_type_description_service_enabled();
     ret = rcl_node_init(this->node_ptr, name, "", this->context_ptr, &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 

--- a/rcl/test/rcl/test_get_type_description_service.cpp
+++ b/rcl/test/rcl/test_get_type_description_service.cpp
@@ -19,6 +19,7 @@
 #include "rcl/service.h"
 #include "rcl/rcl.h"
 
+#include "node_impl.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rosidl_runtime_c/string_functions.h"
 #include "type_description_interfaces/srv/get_type_description.h"
@@ -99,7 +100,7 @@ static bool service_exists(
   return type_name_found;
 }
 
-class CLASSNAME (TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION) : public ::testing::Test
+class CLASSNAME (TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   rcl_context_t * context_ptr;
@@ -133,6 +134,8 @@ public:
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", this->context_ptr, &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ret = rcl_node_type_description_service_init(node_ptr);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
     const char * node_fqn = rcl_node_get_fully_qualified_name(this->node_ptr);
     snprintf(
@@ -153,37 +156,11 @@ public:
   }
 };
 
-class CLASSNAME (TestGetTypeDescSrvDisabledFixture,
-  RMW_IMPLEMENTATION) : public CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION) {
-  bool get_type_description_service_enabled() const override
-  {
-    return false;
-  }
-};
 
-/* Test service being enabled with node_options. */
-TEST_F(
-  CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION),
-  test_service_existence_node_options_default) {
-  EXPECT_TRUE(
-    service_exists(
-      this->node_ptr, this->get_type_description_service_name,
-      GET_TYPE_DESCRIPTION_SRV_TYPE_NAME));
-}
-
-/* Test service being disabled with node_options. */
-TEST_F(
-  CLASSNAME(TestGetTypeDescSrvDisabledFixture, RMW_IMPLEMENTATION),
-  test_service_existence_node_options_disabled) {
-  EXPECT_FALSE(
-    service_exists(
-      this->node_ptr, this->get_type_description_service_name,
-      GET_TYPE_DESCRIPTION_SRV_TYPE_NAME));
-}
 
 /* Test init and fini functions. */
 TEST_F(
-  CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION),
+  CLASSNAME(TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION),
   test_service_init_and_fini_functions) {
   EXPECT_TRUE(
     service_exists(
@@ -205,7 +182,7 @@ TEST_F(
 }
 
 /* Basic nominal test of the ~/get_type_description service. */
-TEST_F(CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION), test_service_nominal) {
+TEST_F(CLASSNAME(TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION), test_service_nominal) {
   rcl_ret_t ret;
   const rosidl_service_type_support_t * ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
     type_description_interfaces, srv, GetTypeDescription);
@@ -248,6 +225,36 @@ TEST_F(CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION), test_ser
   type_description_interfaces__srv__GetTypeDescription_Request__fini(&client_request);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  // This scope simulates handling request in a different context
+  {
+    auto service = &node_ptr->impl->get_type_description_service;
+    ASSERT_TRUE(wait_for_service_to_be_ready(service, context_ptr, 10, 100));
+
+    type_description_interfaces__srv__GetTypeDescription_Response service_response;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      type_description_interfaces__srv__GetTypeDescription_Response__fini(&service_response);
+    });
+
+    type_description_interfaces__srv__GetTypeDescription_Request service_request;
+    type_description_interfaces__srv__GetTypeDescription_Request__init(&service_request);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      type_description_interfaces__srv__GetTypeDescription_Request__fini(&service_request);
+    });
+    rmw_service_info_t header;
+    ret = rcl_take_request_with_info(service, &header, &service_request);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    rcl_node_type_description_service_handle_request(
+      node_ptr,
+      header.request_id,
+      &service_request,
+      &service_response);
+
+    ret = rcl_send_response(service, &header.request_id, &service_response);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  }
+
+  ASSERT_TRUE(wait_for_client_to_be_ready(&client, context_ptr, 10, 100));
   // Initialize the response owned by the client and take the response.
   type_description_interfaces__srv__GetTypeDescription_Response client_response;
   type_description_interfaces__srv__GetTypeDescription_Response__init(&client_response);
@@ -265,7 +272,7 @@ TEST_F(CLASSNAME(TestGetTypeDescSrvEnabledFixture, RMW_IMPLEMENTATION), test_ser
 /* Test calling ~/get_type_description service with invalid hash. */
 TEST_F(
   CLASSNAME(
-    TestGetTypeDescSrvEnabledFixture,
+    TestGetTypeDescSrvFixture,
     RMW_IMPLEMENTATION), test_service_invalid_hash) {
   rcl_ret_t ret;
   const rosidl_service_type_support_t * ts = ROSIDL_GET_SRV_TYPE_SUPPORT(
@@ -300,6 +307,36 @@ TEST_F(
   type_description_interfaces__srv__GetTypeDescription_Request__fini(&client_request);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  // This scope simulates handling request in a different context
+  {
+    auto service = &node_ptr->impl->get_type_description_service;
+    ASSERT_TRUE(wait_for_service_to_be_ready(service, context_ptr, 10, 100));
+
+    type_description_interfaces__srv__GetTypeDescription_Response service_response;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      type_description_interfaces__srv__GetTypeDescription_Response__fini(&service_response);
+    });
+
+    type_description_interfaces__srv__GetTypeDescription_Request service_request;
+    type_description_interfaces__srv__GetTypeDescription_Request__init(&service_request);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      type_description_interfaces__srv__GetTypeDescription_Request__fini(&service_request);
+    });
+    rmw_service_info_t header;
+    ret = rcl_take_request_with_info(service, &header, &service_request);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    rcl_node_type_description_service_handle_request(
+      node_ptr,
+      header.request_id,
+      &service_request,
+      &service_response);
+
+    ret = rcl_send_response(service, &header.request_id, &service_response);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  }
+
+  ASSERT_TRUE(wait_for_client_to_be_ready(&client, context_ptr, 10, 100));
   // Initialize the response owned by the client and take the response.
   type_description_interfaces__srv__GetTypeDescription_Response client_response;
   type_description_interfaces__srv__GetTypeDescription_Response__init(&client_response);

--- a/rcl/test/rcl/test_get_type_description_service.cpp
+++ b/rcl/test/rcl/test_get_type_description_service.cpp
@@ -248,7 +248,7 @@ TEST_F(CLASSNAME(TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION), test_service_no
 
     rcl_node_type_description_service_handle_request(
       node_ptr,
-      header.request_id,
+      &header.request_id,
       &service_request,
       &service_response);
 
@@ -332,7 +332,7 @@ TEST_F(
 
     rcl_node_type_description_service_handle_request(
       node_ptr,
-      header.request_id,
+      &header.request_id,
       &service_request,
       &service_response);
 

--- a/rcl/test/rcl/test_get_type_description_service.cpp
+++ b/rcl/test/rcl/test_get_type_description_service.cpp
@@ -19,10 +19,11 @@
 #include "rcl/service.h"
 #include "rcl/rcl.h"
 
-#include "node_impl.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rosidl_runtime_c/string_functions.h"
 #include "type_description_interfaces/srv/get_type_description.h"
+
+#include "node_impl.h"  // NOLINT
 #include "wait_for_entity_helpers.hpp"
 
 #ifdef RMW_IMPLEMENTATION
@@ -157,7 +158,6 @@ public:
 };
 
 
-
 /* Test init and fini functions. */
 TEST_F(
   CLASSNAME(TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION),
@@ -231,13 +231,15 @@ TEST_F(CLASSNAME(TestGetTypeDescSrvFixture, RMW_IMPLEMENTATION), test_service_no
     ASSERT_TRUE(wait_for_service_to_be_ready(service, context_ptr, 10, 100));
 
     type_description_interfaces__srv__GetTypeDescription_Response service_response;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       type_description_interfaces__srv__GetTypeDescription_Response__fini(&service_response);
     });
 
     type_description_interfaces__srv__GetTypeDescription_Request service_request;
     type_description_interfaces__srv__GetTypeDescription_Request__init(&service_request);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       type_description_interfaces__srv__GetTypeDescription_Request__fini(&service_request);
     });
     rmw_service_info_t header;
@@ -313,13 +315,15 @@ TEST_F(
     ASSERT_TRUE(wait_for_service_to_be_ready(service, context_ptr, 10, 100));
 
     type_description_interfaces__srv__GetTypeDescription_Response service_response;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       type_description_interfaces__srv__GetTypeDescription_Response__fini(&service_response);
     });
 
     type_description_interfaces__srv__GetTypeDescription_Request service_request;
     type_description_interfaces__srv__GetTypeDescription_Request__init(&service_request);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       type_description_interfaces__srv__GetTypeDescription_Request__fini(&service_request);
     });
     rmw_service_info_t header;

--- a/rcl/test/rcl/test_node_type_cache.cpp
+++ b/rcl/test/rcl/test_node_type_cache.cpp
@@ -63,8 +63,6 @@ public:
       this->node_ptr, name, "", this->context_ptr,
       &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_node_type_cache_init(node_ptr);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   void TearDown()

--- a/rcl/test/rcl/test_node_type_cache.cpp
+++ b/rcl/test/rcl/test_node_type_cache.cpp
@@ -64,6 +64,8 @@ public:
       this->node_ptr, name, "", this->context_ptr,
       &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ret = rcl_node_type_cache_init(node_ptr);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   void TearDown()

--- a/rcl/test/rcl/test_node_type_cache.cpp
+++ b/rcl/test/rcl/test_node_type_cache.cpp
@@ -59,7 +59,6 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     constexpr char name[] = "test_type_cache_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    node_options.enable_type_description_service = true;
     ret = rcl_node_init(
       this->node_ptr, name, "", this->context_ptr,
       &node_options);


### PR DESCRIPTION
Based on latest feedback - RCL service should not initialize itself but provide a full API for use by downstream clients, allowing them to register its callback within their execution/waitset framework.